### PR TITLE
Upgrade to admission.k8s.io/v1

### DIFF
--- a/manifests/base/k8s-sidecar-injector.yaml
+++ b/manifests/base/k8s-sidecar-injector.yaml
@@ -116,7 +116,7 @@ webhooks:
       matchExpressions:
         - key: injector.tumblr.com/ignore
           operator: DoesNotExist
-    admissionReviewVersions: ["v1beta1"]
+    admissionReviewVersions: ["v1"]
     sideEffects: None
     timeoutSeconds: 5
     rules:

--- a/test/fixtures/k8s/admissioncontrol/request/env-override.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/env-override.yaml
@@ -1,6 +1,6 @@
 ---
 # this is an AdmissionRequest object
-# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+# https://godoc.org/k8s.io/api/admission/v1#AdmissionRequest
 object:
   metadata:
     annotations:

--- a/test/fixtures/k8s/admissioncontrol/request/missing-sidecar-config.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/missing-sidecar-config.yaml
@@ -1,6 +1,6 @@
 ---
 # this is an AdmissionRequest object
-# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+# https://godoc.org/k8s.io/api/admission/v1#AdmissionRequest
 object:
   metadata:
     annotations:

--- a/test/fixtures/k8s/admissioncontrol/request/prepend-containers.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/prepend-containers.yaml
@@ -1,6 +1,6 @@
 ---
 # this is an AdmissionRequest object
-# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+# https://godoc.org/k8s.io/api/admission/v1#AdmissionRequest
 object:
   metadata:
     annotations:

--- a/test/fixtures/k8s/admissioncontrol/request/service-account-already-set.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/service-account-already-set.yaml
@@ -1,6 +1,6 @@
 ---
 # this is an AdmissionRequest object
-# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+# https://godoc.org/k8s.io/api/admission/v1#AdmissionRequest
 object:
   metadata:
     annotations:

--- a/test/fixtures/k8s/admissioncontrol/request/service-account-default-token.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/service-account-default-token.yaml
@@ -1,6 +1,6 @@
 ---
 # this is an AdmissionRequest object
-# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+# https://godoc.org/k8s.io/api/admission/v1#AdmissionRequest
 object:
   metadata:
     annotations:

--- a/test/fixtures/k8s/admissioncontrol/request/service-account-set-default.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/service-account-set-default.yaml
@@ -1,6 +1,6 @@
 ---
 # this is an AdmissionRequest object
-# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+# https://godoc.org/k8s.io/api/admission/v1#AdmissionRequest
 object:
   metadata:
     annotations:

--- a/test/fixtures/k8s/admissioncontrol/request/service-account.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/service-account.yaml
@@ -1,6 +1,6 @@
 ---
 # this is an AdmissionRequest object
-# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+# https://godoc.org/k8s.io/api/admission/v1#AdmissionRequest
 object:
   metadata:
     annotations:

--- a/test/fixtures/k8s/admissioncontrol/request/sidecar-test-1.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/sidecar-test-1.yaml
@@ -1,6 +1,6 @@
 ---
 # this is an AdmissionRequest object
-# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+# https://godoc.org/k8s.io/api/admission/v1#AdmissionRequest
 object:
   metadata:
     annotations:

--- a/test/fixtures/k8s/admissioncontrol/request/volumetest-existingvolume.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/volumetest-existingvolume.yaml
@@ -1,6 +1,6 @@
 ---
 # this is an AdmissionRequest object
-# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+# https://godoc.org/k8s.io/api/admission/v1#AdmissionRequest
 object:
   metadata:
     annotations:

--- a/test/fixtures/k8s/admissioncontrol/request/volumetest.yaml
+++ b/test/fixtures/k8s/admissioncontrol/request/volumetest.yaml
@@ -1,6 +1,6 @@
 ---
 # this is an AdmissionRequest object
-# https://godoc.org/k8s.io/api/admission/v1beta1#AdmissionRequest
+# https://godoc.org/k8s.io/api/admission/v1#AdmissionRequest
 object:
   metadata:
     annotations:


### PR DESCRIPTION
The v1beta1 version is deprecated and will be removed in 1.22+.

The v1 review validation checks the `kind` and `apiVersion` of the response, which was absent, so I've added that in.  I've also added a test which checks those fields as well as the UID of the response which wasn't captured by
the other mutation tests.