### PR TITLE
Add PodDisruptionBudget

### DIFF
--- a/manifests/base/k8s-sidecar-injector.yaml
+++ b/manifests/base/k8s-sidecar-injector.yaml
@@ -63,6 +63,18 @@ spec:
       labels:
         app.kubernetes.io/name: k8s-sidecar-injector
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - k8s-sidecar-injector
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       serviceAccountName: k8s-sidecar-injector
       volumes:
         - name: configs

--- a/manifests/base/k8s-sidecar-injector.yaml
+++ b/manifests/base/k8s-sidecar-injector.yaml
@@ -32,6 +32,16 @@ spec:
   selector:
     app.kubernetes.io/name: k8s-sidecar-injector
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: k8s-sidecar-injector
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: k8s-sidecar-injector
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -60,7 +70,7 @@ spec:
             name: k8s-sidecar-injector-configs
         - name: secrets
           secret:
-            secretName: k8s-sidecar-injector-webhook-server-cert 
+            secretName: k8s-sidecar-injector-webhook-server-cert
       containers:
         - name: "k8s-sidecar-injector"
           image: quay.io/utilitywarehouse/k8s-sidecar-injector:v0.7.0


### PR DESCRIPTION
If both replicas are drained at the same time then sidecar injections will fail until one of them becomes ready again.