### PR TITLE
manifests: adjust memory requests

### DIFF
--- a/manifests/base/k8s-sidecar-injector.yaml
+++ b/manifests/base/k8s-sidecar-injector.yaml
@@ -109,10 +109,10 @@ spec:
           resources:
             requests:
               cpu: 0m
-              memory: 1Gi
+              memory: 30Mi
             limits:
               cpu: 500m
-              memory: 2Gi
+              memory: 500Mi
           env:
             - name: "TLS_CERT_FILE"
               value: "/var/lib/secrets/tls.crt"


### PR DESCRIPTION
Even in our largest clusters, memory usage is a very steady ~25Mi.